### PR TITLE
Update deps and fix vulnerabilities

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,7 @@ jobs:
     build-linux:
         strategy:
             matrix:
-                rust: [stable, beta, nightly, 1.46.0]
+                rust: [stable, beta, nightly, 1.51.0]
 
         runs-on: ubuntu-latest
         steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ std = []
 async = []
 
 [target.'cfg(loom)'.dependencies]
-loom = "0.3.2"
+loom = "0.5"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ loom = "0.5"
 criterion = "0.3"
 
 [target.'cfg(not(loom))'.dev-dependencies]
-tokio = { version = "0.2.20", features = ["rt-threaded", "macros", "time"] }
-async-std = { version = "1.5.0", features = ["attributes"] }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
+async-std = { version = "1", features = ["attributes"] }
 
 [[bench]]
 name = "benches"

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -39,7 +39,7 @@ async fn await_before_send_tokio() {
     let (sender, receiver) = oneshot::channel();
     let (message, counter) = DropCounter::new(79u128);
     let t = tokio::spawn(async move {
-        tokio::time::delay_for(Duration::from_millis(10)).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
         sender.send(message)
     });
     let returned_message = receiver.await.unwrap();
@@ -70,7 +70,7 @@ async fn await_before_send_async_std() {
 async fn await_before_send_then_drop_sender_tokio() {
     let (sender, receiver) = oneshot::channel::<u128>();
     let t = tokio::spawn(async {
-        tokio::time::delay_for(Duration::from_millis(10)).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
         mem::drop(sender);
     });
     assert!(receiver.await.is_err());
@@ -109,7 +109,7 @@ async fn poll_future_and_then_try_recv() {
 
     let (sender, receiver) = oneshot::channel();
     let t = tokio::spawn(async {
-        tokio::time::delay_for(Duration::from_millis(20)).await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
         mem::drop(sender);
     });
     StupidReceiverFuture(receiver).await.unwrap_err();


### PR DESCRIPTION
Updates a number of vulnerable dependencies. 

Firstly, `loom` which has the `generator` [vulnerability](https://rustsec.org/advisories/RUSTSEC-2020-0151), this should be fully fixed. It also now has the `chrono` [vulnerability](https://rustsec.org/advisories/RUSTSEC-2020-0159), though `loom` still needs a version bump, a simple `cargo update` will suffice once it's released. The [PR](https://github.com/tokio-rs/loom/issues/237) has been merged so it shouldn't be long now. 

I've also updated `tokio` and `async-std`. 

