### PR TITLE
Fix keep latest waker bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Fixed
+- Keep the *last* `Waker` in `Future::poll`, not the *first* one.
 
 
 ## [0.1.2] - 2020-08-11

--- a/tests/future.rs
+++ b/tests/future.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "async")]
+
+use core::{future, mem, pin, task};
+
+#[cfg(loom)]
+pub use loom::sync::{Arc, Mutex};
+#[cfg(not(loom))]
+pub use std::sync::{Arc, Mutex};
+
+mod helpers;
+use helpers::maybe_loom_model;
+
+#[test]
+fn multiple_receiver_polls_keeps_only_latest_waker() {
+    #[derive(Default)]
+    struct MockWaker {
+        cloned: usize,
+        dropped: usize,
+    }
+
+    fn clone_mock_waker(waker: *const ()) -> task::RawWaker {
+        let mock_waker = unsafe { Arc::from_raw(waker as *const Mutex<MockWaker>) };
+        mock_waker.lock().unwrap().cloned += 1;
+        let new_waker =
+            task::RawWaker::new(Arc::into_raw(mock_waker.clone()) as *const (), &VTABLE);
+        mem::forget(mock_waker);
+        new_waker
+    }
+
+    fn drop_mock_waker(waker: *const ()) {
+        let mock_waker = unsafe { Arc::from_raw(waker as *const Mutex<MockWaker>) };
+        mock_waker.lock().unwrap().dropped += 1;
+    }
+
+    const VTABLE: task::RawWakerVTable =
+        task::RawWakerVTable::new(clone_mock_waker, |_| (), |_| (), drop_mock_waker);
+
+    maybe_loom_model(|| {
+        let mock_waker1 = Arc::new(Mutex::new(MockWaker::default()));
+        let raw_waker1 =
+            task::RawWaker::new(Arc::into_raw(mock_waker1.clone()) as *const (), &VTABLE);
+        let waker1 = unsafe { task::Waker::from_raw(raw_waker1) };
+        let mut context1 = task::Context::from_waker(&waker1);
+
+        let (_sender, mut receiver) = oneshot::channel::<()>();
+
+        let poll_result = future::Future::poll(pin::Pin::new(&mut receiver), &mut context1);
+        assert_eq!(poll_result, task::Poll::Pending);
+        assert_eq!(mock_waker1.lock().unwrap().cloned, 1);
+        assert_eq!(mock_waker1.lock().unwrap().dropped, 0);
+
+        let mock_waker2 = Arc::new(Mutex::new(MockWaker::default()));
+        let raw_waker2 =
+            task::RawWaker::new(Arc::into_raw(mock_waker2.clone()) as *const (), &VTABLE);
+        let waker2 = unsafe { task::Waker::from_raw(raw_waker2) };
+        let mut context2 = task::Context::from_waker(&waker2);
+
+        let poll_result = future::Future::poll(pin::Pin::new(&mut receiver), &mut context2);
+        assert_eq!(poll_result, task::Poll::Pending);
+        assert_eq!(mock_waker2.lock().unwrap().cloned, 1);
+        assert_eq!(mock_waker2.lock().unwrap().dropped, 0);
+        assert_eq!(mock_waker1.lock().unwrap().cloned, 1);
+        assert_eq!(mock_waker1.lock().unwrap().dropped, 1);
+    });
+}

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -12,6 +12,13 @@ use loom::sync::{
     Arc,
 };
 
+pub fn maybe_loom_model(test: impl Fn() + Sync + Send + 'static) {
+    #[cfg(loom)]
+    loom::model(test);
+    #[cfg(not(loom))]
+    test();
+}
+
 pub struct DropCounter<T> {
     drop_count: Arc<AtomicUsize>,
     value: Option<T>,

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -20,14 +20,7 @@ mod thread {
 }
 
 mod helpers;
-use helpers::DropCounter;
-
-fn maybe_loom_model(test: impl Fn() + Sync + Send + 'static) {
-    #[cfg(loom)]
-    loom::model(test);
-    #[cfg(not(loom))]
-    test();
-}
+use helpers::{maybe_loom_model, DropCounter};
 
 #[test]
 fn send_before_try_recv() {


### PR DESCRIPTION
Fixes the issue described in https://github.com/faern/oneshot/issues/10#issuecomment-908132265. The `Future` implementation of `Receiver` does not correctly store the last `Waker` it was given, it only stores the first. This PR adds a test showing how it fails when polled multiple times and then fixes the issue.

As far as I'm aware this is not really an issue in practice on `tokio` or `async-std`. But it still breaks the contract of `Future`, so it should of course be fixed to be sound!