### PR TITLE
Fix and improve the Future impl on Sender

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,6 +865,8 @@ impl<T> core::future::Future for Receiver<T> {
                     .compare_exchange(RECEIVING, EMPTY, Relaxed, Relaxed)
                 {
                     // We successfully changed the state back to EMPTY. Replace the waker.
+                    // This is the most likely branch to be taken, which is why we don't use any
+                    // memory barriers in the compare_exchange above.
                     Ok(_) => {
                         // SAFETY: We wrote the waker in a previous call to poll. We do not need
                         // a memory barrier since the previous write here was by ourselves.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -651,26 +651,29 @@ impl<T> Receiver<T> {
     /// Panics if called after this receiver has been polled asynchronously.
     #[cfg(feature = "std")]
     pub fn recv_deadline(&self, deadline: Instant) -> Result<T, RecvTimeoutError> {
+        /// # Safety
+        ///
+        /// The state must be EMPTY (in this case that means UNPARKING) or MESSAGE
+        /// when calling this function. The message must also already have been written to
+        /// the channel and an acquire memory barrier issued to synchronize with that write.
         #[cold]
-        fn wait_for_unpark<T>(channel: &Channel<T>) -> Result<T, RecvTimeoutError> {
+        unsafe fn wait_for_unpark<T>(channel: &Channel<T>) -> Result<T, RecvTimeoutError> {
+            // We have observed the sender setting the UNPARKING state, and we swapped
+            // to the EMPTY state. The state is guaranteed to be EMPTY until the sender
+            // sets it to MESSAGE. No other states are possible here.
             loop {
                 thread::park();
-
-                // ORDERING: synchronize with the write of the message
-                match channel.state.load(Acquire) {
-                    MESSAGE => {
-                        // Same ordering and safety as usual
-
-                        channel.state.store(DISCONNECTED, Relaxed);
-                        break Ok(unsafe { channel.take_message() });
-                    }
-                    // We continue on the empty state here since the current implementation eagerly
-                    // sets the state to EMPTY upon timeout.
-                    EMPTY => (),
-                    // We have observed the sender setting the UNPARKING state, and we swapped
-                    // to the EMPTY state. The state is guaranteed to be EMPTY until the sender
-                    // sets it to MESSAGE. No other states are possible here.
-                    _ => unreachable!(),
+                // ORDERING: This function requires that the message write has already been synchronized
+                // with.
+                // We can't use compare_exchange_weak here since a spurious failure could lead to us
+                // parking indefinitely.
+                if channel
+                    .state
+                    .compare_exchange(MESSAGE, DISCONNECTED, Relaxed, Relaxed)
+                    .is_ok()
+                {
+                    // SAFETY: See safety requirements of this function.
+                    break Ok(channel.take_message());
                 }
             }
         }
@@ -732,10 +735,10 @@ impl<T> Receiver<T> {
                             // The sender sent the message and started unparking us
                             UNPARKING => {
                                 // We were in the UNPARKING state and are now in the EMPTY state.
-                                // We wait to be unparked since this is the only way to maintain
-                                // correctness with intrusive memory.
-
-                                break wait_for_unpark(channel);
+                                // We wait to be properly unparked and to observe the MESSAGE
+                                // state. We need to swap the state back to DISCONNECTED
+                                // in order to avoid reading the message twice.
+                                break unsafe { wait_for_unpark(channel) };
                             }
                             _ => unreachable!(),
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,7 +657,7 @@ impl<T> Receiver<T> {
         /// when calling this function. The message must also already have been written to
         /// the channel and an acquire memory barrier issued to synchronize with that write.
         #[cold]
-        unsafe fn wait_for_unpark<T>(channel: &Channel<T>) -> Result<T, RecvTimeoutError> {
+        unsafe fn wait_for_unpark<T>(channel: &Channel<T>) -> T {
             // We have observed the sender setting the UNPARKING state, and we swapped
             // to the EMPTY state. The state is guaranteed to be EMPTY until the sender
             // sets it to MESSAGE. No other states are possible here.
@@ -673,7 +673,7 @@ impl<T> Receiver<T> {
                     .is_ok()
                 {
                     // SAFETY: See safety requirements of this function.
-                    break Ok(channel.take_message());
+                    break channel.take_message();
                 }
             }
         }
@@ -738,7 +738,7 @@ impl<T> Receiver<T> {
                                 // We wait to be properly unparked and to observe the MESSAGE
                                 // state. We need to swap the state back to DISCONNECTED
                                 // in order to avoid reading the message twice.
-                                break unsafe { wait_for_unpark(channel) };
+                                break Ok(unsafe { wait_for_unpark(channel) });
                             }
                             _ => unreachable!(),
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,9 +891,8 @@ impl<T> core::future::Future for Receiver<T> {
                     Err(UNPARKING) => {
                         // We can't trust that the old waker that the sender has access to
                         // is honored by the async runtime at this point. So we wake ourselves
-                        // up to we get polled instantly again.
+                        // up to get polled instantly again.
                         cx.waker().wake_by_ref();
-                        hint::spin_loop();
                         Poll::Pending
                     }
                     _ => unreachable!(),

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -248,7 +248,7 @@ fn recv_deadline_and_timeout_no_time() {
 // This test doesn't give meaningful results when run with oneshot_test_delay and loom
 #[cfg(all(feature = "std", not(all(oneshot_test_delay, loom))))]
 #[test]
-fn recv_deadline_and_timeout_time_should_elapse() {
+fn recv_deadline_time_should_elapse() {
     maybe_loom_model(|| {
         let (_sender, receiver) = oneshot::channel::<u128>();
 
@@ -263,8 +263,21 @@ fn recv_deadline_and_timeout_time_should_elapse() {
         );
         assert!(start.elapsed() > timeout);
         assert!(start.elapsed() < timeout * 3);
+    })
+}
+
+#[cfg(all(feature = "std", not(all(oneshot_test_delay, loom))))]
+#[test]
+fn recv_timeout_time_should_elapse() {
+    maybe_loom_model(|| {
+        let (_sender, receiver) = oneshot::channel::<u128>();
 
         let start = Instant::now();
+        #[cfg(not(loom))]
+        let timeout = Duration::from_millis(100);
+        #[cfg(loom)]
+        let timeout = Duration::from_millis(1);
+
         assert_eq!(
             receiver.recv_timeout(timeout),
             Err(RecvTimeoutError::Timeout)


### PR DESCRIPTION
Most importantly this fixes the `Future` implementation on `Sender`. 

This PR removes the last usage of `SeqCst` ordering and replaces it with appropriate weaker orderings.