### PR TITLE
Fix try_recv (And add a bunch of loom based tests)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ std = []
 async = []
 
 [target.'cfg(loom)'.dependencies]
-loom = "0.5.3"
+loom = { version = "0.5.3", features = ["futures"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,7 @@ impl<T> Receiver<T> {
             EMPTY => Err(TryRecvError::Empty),
             DISCONNECTED => Err(TryRecvError::Disconnected),
             #[cfg(feature = "async")]
-            RECEIVING => Err(TryRecvError::Empty),
+            RECEIVING | UNPARKING => Err(TryRecvError::Empty),
             _ => unreachable!(),
         }
     }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -12,6 +12,9 @@ use loom::sync::{
     Arc,
 };
 
+#[cfg(loom)]
+pub mod waker;
+
 pub fn maybe_loom_model(test: impl Fn() + Sync + Send + 'static) {
     #[cfg(loom)]
     loom::model(test);

--- a/tests/helpers/waker.rs
+++ b/tests/helpers/waker.rs
@@ -1,0 +1,64 @@
+//! Creates a Waker that can be observed from tests.
+
+use std::mem::forget;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::task::{RawWaker, RawWakerVTable, Waker};
+
+#[derive(Default)]
+pub struct WakerHandle {
+    clone_count: AtomicU32,
+    drop_count: AtomicU32,
+    wake_count: AtomicU32,
+}
+
+impl WakerHandle {
+    pub fn clone_count(&self) -> u32 {
+        self.clone_count.load(Ordering::Relaxed)
+    }
+
+    pub fn drop_count(&self) -> u32 {
+        self.drop_count.load(Ordering::Relaxed)
+    }
+
+    pub fn wake_count(&self) -> u32 {
+        self.wake_count.load(Ordering::Relaxed)
+    }
+}
+
+pub fn waker() -> (Waker, Arc<WakerHandle>) {
+    let waker_handle = Arc::new(WakerHandle::default());
+    let waker_handle_ptr = Arc::into_raw(waker_handle.clone());
+    let raw_waker = RawWaker::new(waker_handle_ptr as *const _, waker_vtable());
+    (unsafe { Waker::from_raw(raw_waker) }, waker_handle)
+}
+
+pub(super) fn waker_vtable() -> &'static RawWakerVTable {
+    &RawWakerVTable::new(clone_raw, wake_raw, wake_by_ref_raw, drop_raw)
+}
+
+unsafe fn clone_raw(data: *const ()) -> RawWaker {
+    let handle: Arc<WakerHandle> = Arc::from_raw(data as *const _);
+    handle.clone_count.fetch_add(1, Ordering::Relaxed);
+    forget(handle.clone());
+    forget(handle);
+    RawWaker::new(data, waker_vtable())
+}
+
+unsafe fn wake_raw(data: *const ()) {
+    let handle: Arc<WakerHandle> = Arc::from_raw(data as *const _);
+    handle.wake_count.fetch_add(1, Ordering::Relaxed);
+    handle.drop_count.fetch_add(1, Ordering::Relaxed);
+}
+
+unsafe fn wake_by_ref_raw(data: *const ()) {
+    let handle: Arc<WakerHandle> = Arc::from_raw(data as *const _);
+    handle.wake_count.fetch_add(1, Ordering::Relaxed);
+    forget(handle)
+}
+
+unsafe fn drop_raw(data: *const ()) {
+    let handle: Arc<WakerHandle> = Arc::from_raw(data as *const _);
+    handle.drop_count.fetch_add(1, Ordering::Relaxed);
+    drop(handle)
+}

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,0 +1,223 @@
+#![cfg(loom)]
+
+use oneshot::TryRecvError;
+
+use loom::hint;
+use loom::thread;
+#[cfg(feature = "async")]
+use std::future::Future;
+#[cfg(feature = "async")]
+use std::pin::Pin;
+#[cfg(feature = "async")]
+use std::task::{self, Poll};
+#[cfg(feature = "std")]
+use std::time::Duration;
+
+mod helpers;
+
+#[test]
+fn try_recv() {
+    loom::model(|| {
+        let (sender, receiver) = oneshot::channel::<u128>();
+
+        let t = thread::spawn(move || loop {
+            match receiver.try_recv() {
+                Ok(msg) => break msg,
+                Err(TryRecvError::Empty) => hint::spin_loop(),
+                Err(TryRecvError::Disconnected) => panic!("Should not be disconnected"),
+            }
+        });
+
+        assert!(sender.send(19).is_ok());
+        assert_eq!(t.join().unwrap(), 19);
+    })
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn send_recv_different_threads() {
+    loom::model(|| {
+        let (sender, receiver) = oneshot::channel();
+        let t2 = thread::spawn(move || {
+            assert_eq!(receiver.recv_timeout(Duration::from_millis(1)), Ok(9));
+        });
+        let t1 = thread::spawn(move || {
+            sender.send(9u128).unwrap();
+        });
+        t1.join().unwrap();
+        t2.join().unwrap();
+    })
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn recv_drop_sender_different_threads() {
+    loom::model(|| {
+        let (sender, receiver) = oneshot::channel::<u128>();
+        let t2 = thread::spawn(move || {
+            assert!(receiver.recv_timeout(Duration::from_millis(0)).is_err());
+        });
+        let t1 = thread::spawn(move || {
+            drop(sender);
+        });
+        t1.join().unwrap();
+        t2.join().unwrap();
+    })
+}
+
+#[cfg(feature = "async")]
+#[test]
+fn async_recv() {
+    loom::model(|| {
+        let (sender, receiver) = oneshot::channel::<u128>();
+        let t1 = thread::spawn(move || {
+            sender.send(987).unwrap();
+        });
+        assert_eq!(loom::future::block_on(receiver), Ok(987));
+        t1.join().unwrap();
+    })
+}
+
+#[cfg(feature = "async")]
+#[test]
+fn send_then_poll() {
+    loom::model(|| {
+        let (sender, mut receiver) = oneshot::channel::<u128>();
+        sender.send(1234).unwrap();
+
+        let (waker, waker_handle) = helpers::waker::waker();
+        let mut context = task::Context::from_waker(&waker);
+
+        assert_eq!(
+            Pin::new(&mut receiver).poll(&mut context),
+            Poll::Ready(Ok(1234))
+        );
+        assert_eq!(waker_handle.clone_count(), 0);
+        assert_eq!(waker_handle.drop_count(), 0);
+        assert_eq!(waker_handle.wake_count(), 0);
+    })
+}
+
+#[cfg(feature = "async")]
+#[test]
+fn poll_then_send() {
+    loom::model(|| {
+        let (sender, mut receiver) = oneshot::channel::<u128>();
+
+        let (waker, waker_handle) = helpers::waker::waker();
+        let mut context = task::Context::from_waker(&waker);
+
+        assert_eq!(Pin::new(&mut receiver).poll(&mut context), Poll::Pending);
+        assert_eq!(waker_handle.clone_count(), 1);
+        assert_eq!(waker_handle.drop_count(), 0);
+        assert_eq!(waker_handle.wake_count(), 0);
+
+        sender.send(1234).unwrap();
+        assert_eq!(waker_handle.clone_count(), 1);
+        assert_eq!(waker_handle.drop_count(), 1);
+        assert_eq!(waker_handle.wake_count(), 1);
+
+        assert_eq!(
+            Pin::new(&mut receiver).poll(&mut context),
+            Poll::Ready(Ok(1234))
+        );
+        assert_eq!(waker_handle.clone_count(), 1);
+        assert_eq!(waker_handle.drop_count(), 1);
+        assert_eq!(waker_handle.wake_count(), 1);
+    })
+}
+
+#[cfg(feature = "async")]
+#[test]
+fn poll_with_different_wakers() {
+    loom::model(|| {
+        let (sender, mut receiver) = oneshot::channel::<u128>();
+
+        let (waker1, waker_handle1) = helpers::waker::waker();
+        let mut context1 = task::Context::from_waker(&waker1);
+
+        assert_eq!(Pin::new(&mut receiver).poll(&mut context1), Poll::Pending);
+        assert_eq!(waker_handle1.clone_count(), 1);
+        assert_eq!(waker_handle1.drop_count(), 0);
+        assert_eq!(waker_handle1.wake_count(), 0);
+
+        let (waker2, waker_handle2) = helpers::waker::waker();
+        let mut context2 = task::Context::from_waker(&waker2);
+
+        assert_eq!(Pin::new(&mut receiver).poll(&mut context2), Poll::Pending);
+        assert_eq!(waker_handle1.clone_count(), 1);
+        assert_eq!(waker_handle1.drop_count(), 1);
+        assert_eq!(waker_handle1.wake_count(), 0);
+
+        assert_eq!(waker_handle2.clone_count(), 1);
+        assert_eq!(waker_handle2.drop_count(), 0);
+        assert_eq!(waker_handle2.wake_count(), 0);
+
+        // Sending should cause the waker from the latest poll to be woken up
+        sender.send(1234).unwrap();
+        assert_eq!(waker_handle1.clone_count(), 1);
+        assert_eq!(waker_handle1.drop_count(), 1);
+        assert_eq!(waker_handle1.wake_count(), 0);
+
+        assert_eq!(waker_handle2.clone_count(), 1);
+        assert_eq!(waker_handle2.drop_count(), 1);
+        assert_eq!(waker_handle2.wake_count(), 1);
+    })
+}
+
+#[cfg(feature = "async")]
+#[test]
+fn poll_then_try_recv() {
+    loom::model(|| {
+        let (_sender, mut receiver) = oneshot::channel::<u128>();
+
+        let (waker, waker_handle) = helpers::waker::waker();
+        let mut context = task::Context::from_waker(&waker);
+
+        assert_eq!(Pin::new(&mut receiver).poll(&mut context), Poll::Pending);
+        assert_eq!(waker_handle.clone_count(), 1);
+        assert_eq!(waker_handle.drop_count(), 0);
+        assert_eq!(waker_handle.wake_count(), 0);
+
+        assert_eq!(receiver.try_recv(), Err(TryRecvError::Empty));
+
+        assert_eq!(Pin::new(&mut receiver).poll(&mut context), Poll::Pending);
+        assert_eq!(waker_handle.clone_count(), 2);
+        assert_eq!(waker_handle.drop_count(), 1);
+        assert_eq!(waker_handle.wake_count(), 0);
+    })
+}
+
+#[cfg(feature = "async")]
+#[test]
+fn poll_then_try_recv_while_sending() {
+    loom::model(|| {
+        let (sender, mut receiver) = oneshot::channel::<u128>();
+
+        let (waker, waker_handle) = helpers::waker::waker();
+        let mut context = task::Context::from_waker(&waker);
+
+        assert_eq!(Pin::new(&mut receiver).poll(&mut context), Poll::Pending);
+        assert_eq!(waker_handle.clone_count(), 1);
+        assert_eq!(waker_handle.drop_count(), 0);
+        assert_eq!(waker_handle.wake_count(), 0);
+
+        let t = thread::spawn(move || {
+            sender.send(1234).unwrap();
+        });
+
+        let msg = loop {
+            match receiver.try_recv() {
+                Ok(msg) => break msg,
+                Err(TryRecvError::Empty) => hint::spin_loop(),
+                Err(TryRecvError::Disconnected) => panic!("Should not be disconnected"),
+            }
+        };
+        assert_eq!(msg, 1234);
+        assert_eq!(waker_handle.clone_count(), 1);
+        assert_eq!(waker_handle.drop_count(), 1);
+        assert_eq!(waker_handle.wake_count(), 1);
+
+        t.join().unwrap();
+    })
+}

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -152,38 +152,6 @@ fn recv_before_send() {
     })
 }
 
-#[cfg(all(feature = "std", loom))]
-#[test]
-fn send_recv_different_threads() {
-    maybe_loom_model(|| {
-        let (sender, receiver) = oneshot::channel();
-        let t2 = thread::spawn(move || {
-            assert_eq!(receiver.recv_timeout(Duration::from_millis(1)), Ok(9));
-        });
-        let t1 = thread::spawn(move || {
-            sender.send(9u128).unwrap();
-        });
-        t1.join().unwrap();
-        t2.join().unwrap();
-    })
-}
-
-#[cfg(all(feature = "std", loom))]
-#[test]
-fn recv_drop_sender_different_threads() {
-    maybe_loom_model(|| {
-        let (sender, receiver) = oneshot::channel::<u128>();
-        let t2 = thread::spawn(move || {
-            assert!(receiver.recv_timeout(Duration::from_millis(0)).is_err());
-        });
-        let t1 = thread::spawn(move || {
-            drop(sender);
-        });
-        t1.join().unwrap();
-        t2.join().unwrap();
-    })
-}
-
 #[cfg(feature = "std")]
 #[test]
 fn recv_timeout_before_send() {


### PR DESCRIPTION
Just after publishing 0.1.4 I realized that the `try_recv` method did not properly handle being in the `UNPARKING` state. I wrote a loom based test proving this was the case, then I fixed the issue. I added a bunch of more loom tests while at it. Verifying that a lot of other poll interactions act sanely.

Ping @Cassy343. What do you think? There are too many combinations on how one can call this library right now. To be fully correct we should also have tests trying to call `recv`, `recv_timeout` etc after polling also. But that's going to explode in number of tests. This will be mitigated with `0.2` where these call combinations are no longer possible.