### PR TITLE
Misc test/benchmark updates, and Sync for Sender/Reciever

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ async = []
 loom = { version = "0.5.3", features = ["futures"] }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [target.'cfg(not(loom))'.dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1178,7 +1178,7 @@ fn receiver_waker_size() {
         (false, false) => 0,
         (false, true) => 16,
         (true, false) => 8,
-        (true, true) => 24,
+        (true, true) => 16,
     };
     assert_eq!(mem::size_of::<ReceiverWaker>(), expected);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,8 @@ pub struct Receiver<T> {
 
 unsafe impl<T: Send> Send for Sender<T> {}
 unsafe impl<T: Send> Send for Receiver<T> {}
+unsafe impl<T: Sync> Sync for Sender<T> {}
+unsafe impl<T: Sync> Sync for Receiver<T> {}
 impl<T> Unpin for Receiver<T> {}
 
 impl<T> Sender<T> {


### PR DESCRIPTION
Fixes #8.
Fixes #26.
Relates to #4, since the size of the waker seems to have decreased (looks like the discriminant is able to fit in the niche for a reference).

* Cleanup benchmarks to avoid creation in every case
* Use const generics to move code out of macro
* Upgrade to criterion 0.5 from 0.3
* Implement Sync for Sender/Receiver 
