### PR TITLE
Remove unnecessary use of unsafe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,11 +183,7 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
     // Allocate the channel on the heap and get the pointer.
     // The last endpoint of the channel to be alive is responsible for freeing the channel
     // and dropping any object that might have been written to it.
-
-    let channel_ptr = Box::into_raw(Box::new(Channel::new()));
-
-    // SAFETY: `channel_ptr` came from a Box and thus is not null
-    let channel_ptr = unsafe { NonNull::new_unchecked(channel_ptr) };
+    let channel_ptr = NonNull::from(Box::leak(Box::new(Channel::new())));
 
     (
         Sender {

--- a/src/loombox.rs
+++ b/src/loombox.rs
@@ -15,6 +15,13 @@ impl<T> Box<T> {
 }
 
 impl<T: ?Sized> Box<T> {
+    pub fn leak<'a>(b: Self) -> &'a mut T
+    where
+        T: 'a,
+    {
+        unsafe { &mut *Box::into_raw(b) }
+    }
+
     #[inline]
     pub fn into_raw(b: Box<T>) -> *mut T {
         let ptr = b.ptr;


### PR DESCRIPTION
Basically use `Box::leak` instead of `Box::into_raw`, resulting in a `&mut T` instead of `*mut T`, statically guaranteeing nonnull-ness.

This does not affect the MSRV (`1.60` at the time of writing)

Also removes an import that `clippy` is complaining about. (Unused on all feature combinations)
