### PR TITLE
Added is_closed method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,25 @@ impl<T> Sender<T> {
         }
     }
 
+    /// Returns true if the associated Receiver handle has been dropped.
+    ///
+    /// If true is returned, a future call to send is guaranteed to return an error.
+    pub fn is_closed(&self) -> bool {
+        // SAFETY: Since we are holding a Sender's reference, we know that:
+        // - `send(..)` has not been called yet
+        // - `Sender` has not been dropped.
+        //
+        // This is sufficient to guarantee that the channel is still on the heap.
+        //
+        // Note that if the receiver disconnects it does not free the channel.
+        let channel = unsafe { self.channel_ptr.as_ref() };
+
+        // ORDERING: We *chose* a Relaxed ordering here as it sufficient to
+        // enforce the method's contract: "if true is returned, a future
+        // call to send is guaranteed to return an error."
+        channel.state.load(Relaxed) == DISCONNECTED
+    }
+
     /// Consumes the Sender, returning a raw pointer to the channel on the heap.
     ///
     /// This is intended to simplify using oneshot channels with some FFI code. The only safe thing

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -343,3 +343,13 @@ fn send_error_drops_message_correctly_on_into_inner() {
         assert_eq!(counter.count(), 1);
     });
 }
+
+#[test]
+fn dropping_receiver_disconnects_sender() {
+    maybe_loom_model(|| {
+        let (sender, receiver) = oneshot::channel::<()>();
+        assert!(!sender.is_closed());
+        drop(receiver);
+        assert!(sender.is_closed());
+    });
+}


### PR DESCRIPTION
This adds a `is_closed` method to the oneshot Sender.

The naming was copied from tokio's oneshot.
This PR was motivated by the following need.

A thread pool executor queues `FnOnce()->T` on a thread pool.
The method used to schedule the execution of such a function returns a Receiver.

When the execution of a function arrives, `is_closed` makes it possible on the executor side to detect that no one is actually waiting on the result anymore, and the executor can skip the execution of the function entirely.