### PR TITLE
re-enable "unexpected_cfgs" lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ criterion = "0.3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
 async-std = { version = "1", features = ["attributes"] }
 
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(loom)', 'cfg(oneshot_test_delay)'] }
+
 [[bench]]
 name = "benches"
 harness = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,6 @@
 // [1]: Mind that the waker only takes zero bytes when all features are disabled, making it
 //      impossible to *wait* for the message. `try_recv` the only available method in this scenario.
 
-#![allow(unexpected_cfgs)]
 #![deny(rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,4 +1,3 @@
-#![allow(unexpected_cfgs)]
 #![cfg(all(feature = "async", not(loom)))]
 
 use core::mem;

--- a/tests/future.rs
+++ b/tests/future.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "async")]
-#![allow(unexpected_cfgs)]
 
 use core::{future, mem, pin, task};
 

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,4 +1,3 @@
-#![allow(unexpected_cfgs)]
 #![cfg(loom)]
 
 use oneshot::TryRecvError;

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -1,4 +1,3 @@
-#![allow(unexpected_cfgs)]
 #![cfg(not(loom))]
 
 use oneshot::{channel, Receiver, Sender};

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1,5 +1,3 @@
-#![allow(unexpected_cfgs)]
-
 use core::mem;
 use oneshot::TryRecvError;
 


### PR DESCRIPTION
Closes #34 

Enables the `unexpected_cfgs` lint as described in https://github.com/faern/oneshot/issues/34#issuecomment-2124659776