### PR TITLE
Make loom optional

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,13 +39,13 @@ jobs:
       - name: Build
         run: cargo build
 
+      # Run `cargo test` with all combinations of features. Including loom correctness testing
       - name: Test
-        run: cargo hack --feature-powerset test
+        run: cargo hack --feature-powerset --exclude-all-features --optional-deps loom test
 
+      # Run `cargo test` but with artificial delay injected into some code paths. This helps
+      # running through some hard-to-time code paths. loom testing is not included since it is not
+      # compatible nor make any sense together with sleeping.
       - name: Test with artificial delay
         shell: bash
-        run: RUSTFLAGS+="--cfg oneshot_test_delay" cargo hack --feature-powerset test
-
-      - name: Test with loom
-        shell: bash
-        run: RUSTFLAGS+="--cfg loom" LOOM_MAX_BRANCHES=100000 cargo hack --feature-powerset test --test sync --test loom
+        run: RUSTFLAGS+="--cfg oneshot_test_delay" cargo hack --feature-powerset --exclude-all-features test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Changed
+- Change how loom concurrency testing is triggered. Make it an optional dependency instead of
+  placed behind a custom `cfg(loom)`. This has the pros that it does not end up in the dependency
+  tree of `oneshot` (unless the optional feature `loom` is enabled), which makes this library
+  way smaller for downstream consumers. This has the downside that the crate now exposes a `loom`
+  feature. DOWNSTREAM USERS ARE NOT SUPPOSED TO EVER ENABLE THIS. No stability or semver
+  guarantees exist around the `loom` feature.
 
 
 ## [0.1.7] - 2024-05-24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ loom = { version = "0.7.2", features = ["futures"], optional = true }
 [dev-dependencies]
 criterion = "0.3"
 
-[target.'cfg(not(loom))'.dev-dependencies]
+[target.'cfg(not(feature = "loom"))'.dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
 async-std = { version = "1", features = ["attributes"] }
 
 [lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(loom)', 'cfg(oneshot_test_delay)'] }
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(oneshot_test_delay)'] }
 
 [[bench]]
 name = "benches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ loom = { version = "0.7.2", features = ["futures"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
-
-[target.'cfg(not(feature = "loom"))'.dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
 async-std = { version = "1", features = ["attributes"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,9 @@ std = []
 # Enables async receiving by implementing Future
 async = []
 
-[target.'cfg(loom)'.dependencies]
-loom = { version = "0.7.2", features = ["futures"] }
+[dependencies]
+# Only used for internal correctness testing. Never enable this feature when using oneshot.
+loom = { version = "0.7.2", features = ["futures"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! can receive both blocking and async.
 //!
 //! ```rust
+//! # #[cfg(not(feature = "loom"))] {
 //! use std::sync::mpsc;
 //! use std::thread;
 //! use std::time::Duration;
@@ -71,6 +72,7 @@
 //!             }
 //!         });
 //! }
+//! # }
 //! ```
 //!
 //! # Sync vs async

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,7 +486,7 @@ impl<T> Receiver<T> {
                 // Conditionally add a delay here to help the tests trigger the edge cases where
                 // the sender manages to be dropped or send something before we are able to store
                 // our waker object in the channel.
-                #[cfg(oneshot_test_delay)]
+                #[cfg(all(oneshot_test_delay, not(feature = "loom")))]
                 std::thread::sleep(std::time::Duration::from_millis(10));
 
                 // Write our waker instance to the channel.
@@ -793,7 +793,7 @@ impl<T> Receiver<T> {
                 // Conditionally add a delay here to help the tests trigger the edge cases where
                 // the sender manages to be dropped or send something before we are able to store
                 // our waker object in the channel.
-                #[cfg(oneshot_test_delay)]
+                #[cfg(all(oneshot_test_delay, not(feature = "loom")))]
                 std::thread::sleep(std::time::Duration::from_millis(10));
 
                 // Write our waker instance to the channel.

--- a/src/loombox.rs
+++ b/src/loombox.rs
@@ -65,25 +65,25 @@ impl<T: ?Sized> core::ops::DerefMut for Box<T> {
 
 impl<T: ?Sized> borrow::Borrow<T> for Box<T> {
     fn borrow(&self) -> &T {
-        &**self
+        self
     }
 }
 
 impl<T: ?Sized> borrow::BorrowMut<T> for Box<T> {
     fn borrow_mut(&mut self) -> &mut T {
-        &mut **self
+        self
     }
 }
 
 impl<T: ?Sized> AsRef<T> for Box<T> {
     fn as_ref(&self) -> &T {
-        &**self
+        self
     }
 }
 
 impl<T: ?Sized> AsMut<T> for Box<T> {
     fn as_mut(&mut self) -> &mut T {
-        &mut **self
+        self
     }
 }
 

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "async", not(loom)))]
+#![cfg(all(feature = "async", not(feature = "loom")))]
 
 use core::mem;
 use core::time::Duration;

--- a/tests/future.rs
+++ b/tests/future.rs
@@ -2,9 +2,9 @@
 
 use core::{future, mem, pin, task};
 
-#[cfg(loom)]
+#[cfg(feature = "loom")]
 pub use loom::sync::{Arc, Mutex};
-#[cfg(not(loom))]
+#[cfg(not(feature = "loom"))]
 pub use std::sync::{Arc, Mutex};
 
 mod helpers;

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -2,23 +2,23 @@
 
 extern crate alloc;
 
-#[cfg(not(loom))]
+#[cfg(not(feature = "loom"))]
 use alloc::sync::Arc;
-#[cfg(not(loom))]
+#[cfg(not(feature = "loom"))]
 use core::sync::atomic::{AtomicUsize, Ordering::SeqCst};
-#[cfg(loom)]
+#[cfg(feature = "loom")]
 use loom::sync::{
     atomic::{AtomicUsize, Ordering::SeqCst},
     Arc,
 };
 
-#[cfg(loom)]
+#[cfg(feature = "loom")]
 pub mod waker;
 
 pub fn maybe_loom_model(test: impl Fn() + Sync + Send + 'static) {
-    #[cfg(loom)]
+    #[cfg(feature = "loom")]
     loom::model(test);
-    #[cfg(not(loom))]
+    #[cfg(not(feature = "loom"))]
     test();
 }
 

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,4 +1,4 @@
-#![cfg(loom)]
+#![cfg(feature = "loom")]
 
 use oneshot::TryRecvError;
 

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -1,4 +1,4 @@
-#![cfg(not(loom))]
+#![cfg(not(feature = "loom"))]
 
 use oneshot::{channel, Receiver, Sender};
 

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -8,12 +8,12 @@ use std::time::{Duration, Instant};
 
 #[cfg(feature = "std")]
 mod thread {
-    #[cfg(loom)]
+    #[cfg(feature = "loom")]
     pub use loom::thread::spawn;
-    #[cfg(not(loom))]
+    #[cfg(not(feature = "loom"))]
     pub use std::thread::{sleep, spawn};
 
-    #[cfg(loom)]
+    #[cfg(feature = "loom")]
     pub fn sleep(_timeout: core::time::Duration) {
         loom::thread::yield_now()
     }
@@ -59,7 +59,7 @@ fn send_before_recv() {
     // FIXME: This test does not work with loom. There is something that happens after the
     // channel object becomes larger than ~500 bytes and that makes an atomic read from the state
     // result in "signal: 10, SIGBUS: access to undefined memory"
-    #[cfg(not(loom))]
+    #[cfg(not(feature = "loom"))]
     maybe_loom_model(|| {
         let (sender, receiver) = oneshot::channel::<[u8; 4096]>();
         assert!(sender.send([0b10101010; 4096]).is_ok());
@@ -246,16 +246,16 @@ fn recv_deadline_and_timeout_no_time() {
 }
 
 // This test doesn't give meaningful results when run with oneshot_test_delay and loom
-#[cfg(all(feature = "std", not(all(oneshot_test_delay, loom))))]
+#[cfg(all(feature = "std", not(all(oneshot_test_delay, feature = "loom"))))]
 #[test]
 fn recv_deadline_time_should_elapse() {
     maybe_loom_model(|| {
         let (_sender, receiver) = oneshot::channel::<u128>();
 
         let start = Instant::now();
-        #[cfg(not(loom))]
+        #[cfg(not(feature = "loom"))]
         let timeout = Duration::from_millis(100);
-        #[cfg(loom)]
+        #[cfg(feature = "loom")]
         let timeout = Duration::from_millis(1);
         assert_eq!(
             receiver.recv_deadline(start + timeout),
@@ -266,16 +266,16 @@ fn recv_deadline_time_should_elapse() {
     })
 }
 
-#[cfg(all(feature = "std", not(all(oneshot_test_delay, loom))))]
+#[cfg(all(feature = "std", not(all(oneshot_test_delay, feature = "loom"))))]
 #[test]
 fn recv_timeout_time_should_elapse() {
     maybe_loom_model(|| {
         let (_sender, receiver) = oneshot::channel::<u128>();
 
         let start = Instant::now();
-        #[cfg(not(loom))]
+        #[cfg(not(feature = "loom"))]
         let timeout = Duration::from_millis(100);
-        #[cfg(loom)]
+        #[cfg(feature = "loom")]
         let timeout = Duration::from_millis(1);
 
         assert_eq!(
@@ -287,7 +287,7 @@ fn recv_timeout_time_should_elapse() {
     })
 }
 
-#[cfg(not(loom))]
+#[cfg(not(feature = "loom"))]
 #[test]
 fn non_send_type_can_be_used_on_same_thread() {
     use std::ptr;


### PR DESCRIPTION
I have come to realize that with:
```toml
[target.'cfg(loom)'.dependencies]
loom = { version = "0.7.2", features = ["futures"] }
```
loom is pulled in as a mandatory dependency and pollutes `Cargo.lock`. This means it pollutes the dependency tree by quite a lot. This should be a small and lightweight library, so that's not ideal. Downstream users of this library should not need to have the entire `loom` dependency tree in their supply chain, they will/should never use it!

This PR explores making loom a proper optional dependency instead.