### PR TITLE
Improve CI (--locked and documentation)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,11 +37,13 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
 
       - name: Build
+        shell: bash
         run: cargo build --locked
 
       # Run `cargo test` with all combinations of features. Including loom correctness testing
       - name: Test
-        run: cargo hack --feature-powerset --exclude-all-features --optional-deps loom test
+        shell: bash
+        run: LOOM_MAX_BRANCHES=100000 cargo hack --feature-powerset --exclude-all-features --optional-deps loom test
 
       # Run `cargo test` but with artificial delay injected into some code paths. This helps
       # running through some hard-to-time code paths. loom testing is not included since it is not

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
 
       - name: Build
-        run: cargo build
+        run: cargo build --locked
 
       # Run `cargo test` with all combinations of features. Including loom correctness testing
       - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,3 +49,8 @@ jobs:
       - name: Test with artificial delay
         shell: bash
         run: RUSTFLAGS+="--cfg oneshot_test_delay" cargo hack --feature-powerset --exclude-all-features test
+
+      # Check that the documentation builds and has no warnings
+      - name: Build documentation
+        shell: bash
+        run: RUSTDOCFLAGS="--deny warnings" cargo hack --feature-powerset --exclude-all-features doc

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -80,13 +80,15 @@ impl<T> fmt::Debug for SendError<T> {
 #[cfg(feature = "std")]
 impl<T> std::error::Error for SendError<T> {}
 
-/// An error returned from the blocking [`Receiver::recv`](crate::Receiver::recv) method.
+/// An error returned from receiving methods that block/wait until a message is available.
 ///
 /// The receive operation can only fail if the corresponding [`Sender`](crate::Sender) was dropped
-/// before sending any message, or if a message has already been sent and received on the channel.
+/// before sending any message, or if a message has already been received on the channel.
+#[cfg(any(feature = "std", feature = "async"))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct RecvError;
 
+#[cfg(any(feature = "std", feature = "async"))]
 impl fmt::Display for RecvError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "receiving on a closed channel".fmt(f)
@@ -121,8 +123,9 @@ impl fmt::Display for TryRecvError {
 #[cfg(feature = "std")]
 impl std::error::Error for TryRecvError {}
 
-/// An error returned when failing to receive a message in
-/// [`Receiver::recv_timeout`](crate::Receiver::recv_timeout).
+/// An error returned when failing to receive a message in a method that block/wait for a message
+/// for a while, but has a timeout after which it gives up.
+#[cfg(feature = "std")]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum RecvTimeoutError {
     /// No message arrived on the channel before the timeout was reached. The channel is still open.
@@ -133,6 +136,7 @@ pub enum RecvTimeoutError {
     Disconnected,
 }
 
+#[cfg(feature = "std")]
 impl fmt::Display for RecvTimeoutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,9 @@ use alloc::boxed::Box;
 use loombox::Box;
 
 mod errors;
-pub use errors::{RecvError, RecvTimeoutError, SendError, TryRecvError};
+// Wildcard imports are not nice. But since multiple errors have various conditional compilation,
+// this is easier than doing three different imports.
+pub use errors::*;
 
 /// Creates a new oneshot channel and returns the two endpoints, [`Sender`] and [`Receiver`].
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {


### PR DESCRIPTION
* Build the crate with `--locked` to catch if `Cargo.lock` is outdated
* Build documentation to catch if it has broken links and other warnings (spoiler: it did)
* Add back `LOOM_MAX_BRANCHES=100000` since tests are flaky (apparently they still fail from time to time, but going to ignore that for now)