### PR TITLE
Ignore receiver_waker_size test since it's unstable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1237,6 +1237,7 @@ impl ReceiverWaker {
 
 #[cfg(not(oneshot_loom))]
 #[test]
+#[ignore = "Unstable test. Different Rust versions have different sizes for Thread"]
 fn receiver_waker_size() {
     let expected: usize = match (cfg!(feature = "std"), cfg!(feature = "async")) {
         (false, false) => 0,


### PR DESCRIPTION
At first I just updated the sizes to match stable Rust 1.84. But I then realized the size of `Thread` was smaller again on nightly. So let's ignore the test for now and see what the standard library settles on, if anything stable at all. The standard library give no size guarantees about the struct we are testing the size of, so this test is inherently unstable! The problem lies in this library, not in `std`. I just want to have this test in place to catch library bugs that cause the `ReceiverWaker` to blow up in size unintentionally.

The Rust PR that reverted the size increase of `std::thread::Thread`, and made it go back to pre Rust 1.84 sizes is this one: https://github.com/rust-lang/rust/pull/132654