### PR TITLE
Implement `Sync` for `Sender`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Implement `Sync` for `Sender`. There is not a whole lot someone can do with a `&Sender`,
+  but this allows storing the sender in places that are overly conservative and require
+  a `Sync` bound on the content.
 
 
 ## [0.1.8] - 2024-06-13

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,12 @@ pub struct Receiver<T> {
 }
 
 unsafe impl<T: Send> Send for Sender<T> {}
+
+// SAFETY: The only methods that assumes there is only a single reference to the sender
+// takes `self` by value, guaranteeing that there is only one reference to the sender at
+// the time it is called.
+unsafe impl<T: Sync> Sync for Sender<T> {}
+
 unsafe impl<T: Send> Send for Receiver<T> {}
 impl<T> Unpin for Receiver<T> {}
 


### PR DESCRIPTION
Fixes #46 and partially #26.

I avoided this initially since the type is supposed to be single producer. I myself did not run into any use case where I needed the sender to be sync. But #46 has a good argument for it: Storing the sender in an overly conservative container that requires `Sync` on its content.

No, the `Receiver` can definitely not be `Sync`. See this explanation: https://github.com/faern/oneshot/issues/26#issuecomment-1627681774