### PR TITLE
Add `is_closed` and `has_message` to the Receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Add `is_closed` and `has_message` to the `Receiver`. Allows polling for the channel
+  state without modifying the channel or pulling the message from it.
 
 
 ## [0.1.9] - 2025-02-02


### PR DESCRIPTION
Allows polling the receiver for the channel state, without changing it or without pulling any message out.

Does this allow using `oneshot` in the way you needed it @szostid ? Sure, if your code needs to know both whether or not the channel is disconnected and if there is a message, this solution requires two method calls (and two atomic loads) instead of one. But is that a real world use case? I imagine for the majority of places where you need to check the state you are either interested in knowing if there is a message to be read, or if the sender gave up and aborted.

I could also consider going more towards your suggested route in #52. But only if we slim down the state enum to just expose `Empty`, `Message`, and `Disconnected`. The three states that any receiver code could reasonably care about? But that method would then not be mutually exclusive with these helper methods. For those that only need to check if a message is available or not, calling `has_message` is going to provide better API ergonomics than matching an enum.