### PR TITLE
Add feature indicators to docs.rs documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,7 @@ unexpected_cfgs = { level = "deny", check-cfg = ['cfg(oneshot_loom)', 'cfg(onesh
 [[bench]]
 name = "benches"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,9 @@
 
 #![deny(rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
+// Enables this nightly only feature for the documentation build on docs.rs.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(not(oneshot_loom))]
 extern crate alloc;


### PR DESCRIPTION
Shows what feature must be enabled for each method to be available.

This was split out from #57. Since this part alone is not API breaking.