### PR TITLE
Handle UNPARKING state in Receiver::drop()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Handle the UNPARKING state correctly in `Receiver::drop()`.
+
 
 ## [0.1.10] - 2025-02-04
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1056,8 +1056,7 @@ impl<T> Drop for Receiver<T> {
             #[cfg(any(feature = "std", feature = "async"))]
             UNPARKING => loop {
                 hint::spin_loop();
-                // ORDERING: We do not care about the message anymore since we are being dropped,
-                // all we want to know is when the sender is done exercising the waker.
+                // ORDERING: The load above has already synchronized with the write of the message.
                 match channel.state.load(Relaxed) {
                     MESSAGE => {
                         // SAFETY: we are in the message state so the message is initialized


### PR DESCRIPTION
I am observing that the `unreachable!()` branch is occasionally hit in `Receiver::drop()` under multithreaded load in async scenarios. This appears to be because the `UNPARKING` state is not handled in the `match`. Now it is.

I am not 100% confident in the correctness of the logic I added here - while the code in this crate is very well commented and proved easy to work with, I do not quite have the right state transitions mapped out in my head. Therefore, I just tried to follow what a similar block in a recv implementation above does. It eliminated this crash for me, at least, but perhaps I missed something. I am not even 100% convinced whether/when the `UNPARKING` state can be reached here (I cannot rule out a programming error in my code using `oneshot` wrongly).