### PR TITLE
Add separate `AsyncReceiver` type instead of implementing `Future` directly on the `Receiver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Add a separate type `AsyncReceiver` that implements `Future` instead of implementing it
+  directly on the `Receiver` type. Now the `Receiver` implements `IntoFuture` instead.
+  This is a breaking change. This change removes the possible panics in many recv* methods,
+  and it simplifies some code a bit.
+
 
 ## [0.1.10] - 2025-02-04
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! The sender's send method is non-blocking, and potentially lock- and wait-free.
 //! See documentation on [Sender::send] for situations where it might not be fully wait-free.
 //! The receiver supports both lock- and wait-free `try_recv` as well as indefinite and time
-//! limited thread blocking receive operations. The receiver also implements `Future` and
+//! limited thread blocking receive operations. The receiver also implements `IntoFuture` and
 //! supports asynchronously awaiting the message.
 //!
 //!
@@ -83,10 +83,10 @@
 //! that should work smoothly between the sync and async parts of the program!
 //!
 //! This library achieves that by having a fast and cheap send operation that can
-//! be used in both sync threads and async tasks. The receiver has both thread blocking
-//! receive methods for synchronous usage, and implements `Future` for asynchronous usage.
+//! be used in both regular threads and async tasks. The receiver has both thread blocking
+//! receive methods for synchronous usage, and implements `IntoFuture` for asynchronous usage.
 //!
-//! The receiving endpoint of this channel implements Rust's `Future` trait and can be waited on
+//! The receiving endpoint of this channel implements Rust's `IntoFuture` trait and can be waited on
 //! in an asynchronous task. This implementation is completely executor/runtime agnostic. It should
 //! be possible to use this library with any executor, or even pass messages between tasks running
 //! in different executors.

--- a/tests/future.rs
+++ b/tests/future.rs
@@ -42,7 +42,7 @@ fn multiple_receiver_polls_keeps_only_latest_waker() {
         let waker1 = unsafe { task::Waker::from_raw(raw_waker1) };
         let mut context1 = task::Context::from_waker(&waker1);
 
-        let (_sender, mut receiver) = oneshot::channel::<()>();
+        let (_sender, mut receiver) = oneshot::async_channel::<()>();
 
         let poll_result = future::Future::poll(pin::Pin::new(&mut receiver), &mut context1);
         assert_eq!(poll_result, task::Poll::Pending);

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -5,7 +5,7 @@ use oneshot::TryRecvError;
 use loom::hint;
 use loom::thread;
 #[cfg(feature = "async")]
-use std::future::Future;
+use std::future::{Future, IntoFuture};
 #[cfg(feature = "async")]
 use std::pin::Pin;
 #[cfg(feature = "async")]
@@ -73,7 +73,7 @@ fn async_recv() {
         let t1 = thread::spawn(move || {
             sender.send(987).unwrap();
         });
-        assert_eq!(loom::future::block_on(receiver), Ok(987));
+        assert_eq!(loom::future::block_on(receiver.into_future()), Ok(987));
         t1.join().unwrap();
     })
 }
@@ -82,7 +82,7 @@ fn async_recv() {
 #[test]
 fn send_then_poll() {
     loom::model(|| {
-        let (sender, mut receiver) = oneshot::channel::<u128>();
+        let (sender, mut receiver) = oneshot::async_channel::<u128>();
         sender.send(1234).unwrap();
 
         let (waker, waker_handle) = helpers::waker::waker();
@@ -102,7 +102,7 @@ fn send_then_poll() {
 #[test]
 fn poll_then_send() {
     loom::model(|| {
-        let (sender, mut receiver) = oneshot::channel::<u128>();
+        let (sender, mut receiver) = oneshot::async_channel::<u128>();
 
         let (waker, waker_handle) = helpers::waker::waker();
         let mut context = task::Context::from_waker(&waker);
@@ -131,7 +131,7 @@ fn poll_then_send() {
 #[test]
 fn poll_with_different_wakers() {
     loom::model(|| {
-        let (sender, mut receiver) = oneshot::channel::<u128>();
+        let (sender, mut receiver) = oneshot::async_channel::<u128>();
 
         let (waker1, waker_handle1) = helpers::waker::waker();
         let mut context1 = task::Context::from_waker(&waker1);
@@ -162,62 +162,5 @@ fn poll_with_different_wakers() {
         assert_eq!(waker_handle2.clone_count(), 1);
         assert_eq!(waker_handle2.drop_count(), 1);
         assert_eq!(waker_handle2.wake_count(), 1);
-    })
-}
-
-#[cfg(feature = "async")]
-#[test]
-fn poll_then_try_recv() {
-    loom::model(|| {
-        let (_sender, mut receiver) = oneshot::channel::<u128>();
-
-        let (waker, waker_handle) = helpers::waker::waker();
-        let mut context = task::Context::from_waker(&waker);
-
-        assert_eq!(Pin::new(&mut receiver).poll(&mut context), Poll::Pending);
-        assert_eq!(waker_handle.clone_count(), 1);
-        assert_eq!(waker_handle.drop_count(), 0);
-        assert_eq!(waker_handle.wake_count(), 0);
-
-        assert_eq!(receiver.try_recv(), Err(TryRecvError::Empty));
-
-        assert_eq!(Pin::new(&mut receiver).poll(&mut context), Poll::Pending);
-        assert_eq!(waker_handle.clone_count(), 2);
-        assert_eq!(waker_handle.drop_count(), 1);
-        assert_eq!(waker_handle.wake_count(), 0);
-    })
-}
-
-#[cfg(feature = "async")]
-#[test]
-fn poll_then_try_recv_while_sending() {
-    loom::model(|| {
-        let (sender, mut receiver) = oneshot::channel::<u128>();
-
-        let (waker, waker_handle) = helpers::waker::waker();
-        let mut context = task::Context::from_waker(&waker);
-
-        assert_eq!(Pin::new(&mut receiver).poll(&mut context), Poll::Pending);
-        assert_eq!(waker_handle.clone_count(), 1);
-        assert_eq!(waker_handle.drop_count(), 0);
-        assert_eq!(waker_handle.wake_count(), 0);
-
-        let t = thread::spawn(move || {
-            sender.send(1234).unwrap();
-        });
-
-        let msg = loop {
-            match receiver.try_recv() {
-                Ok(msg) => break msg,
-                Err(TryRecvError::Empty) => hint::spin_loop(),
-                Err(TryRecvError::Disconnected) => panic!("Should not be disconnected"),
-            }
-        };
-        assert_eq!(msg, 1234);
-        assert_eq!(waker_handle.clone_count(), 1);
-        assert_eq!(waker_handle.drop_count(), 1);
-        assert_eq!(waker_handle.wake_count(), 1);
-
-        t.join().unwrap();
     })
 }


### PR DESCRIPTION
This PR adds a separate type, `AsyncReceiver`, that implements `Future`, instead of implementing it directly on the `Receiver` type. Now the `Receiver` implements `IntoFuture` instead. 

This change removes the possible panics in many recv* methods, and it simplifies some code a bit.

This is a breaking change.