### PR TITLE
feat: Add `extra-platforms` feature for non-atomic targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "async-std",
  "criterion",
  "loom",
+ "portable-atomic",
  "tokio",
 ]
 
@@ -704,6 +705,12 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ std = []
 # Enables async receiving via the AsyncReceiver receiver
 async = []
 
+[dependencies]
+# Use portable-atomic crate to support platforms without atomic CAS.
+# Enable require-cas feature to provide an error message if dependents require atomic CAS but the end user forgets to use single-core cfg or critical-section feature.
+extra-platforms = { package = "portable-atomic", version = "1.3", optional = true, default-features = false, features = ["require-cas"] }
+
 # Only used for internal correctness testing.
 # Downstream users of oneshot should never enable this feature. Enabling it does nothing.
 # To compile oneshot built against loom one must *also* set RUSTFLAGS="--cfg oneshot_loom"

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -1,4 +1,6 @@
-#[cfg(not(oneshot_loom))]
+#[cfg(not(any(oneshot_loom, feature = "extra-platforms")))]
 pub use core::sync::atomic::{AtomicU8, Ordering, fence};
+#[cfg(feature = "extra-platforms")]
+pub use extra_platforms::{AtomicU8, Ordering, fence};
 #[cfg(oneshot_loom)]
 pub use loom::sync::atomic::{AtomicU8, Ordering, fence};


### PR DESCRIPTION
Introduce a new Cargo feature, `extra-platforms`, to add support for hardware targets that lack native atomic CAS operations.

The library relies on `AtomicU8`, which is not available on all platforms (e.g., certain embedded targets like `riscv32i` or `thumbv6m`). This prevents the crate from being used in those environments.

This change "poly-fills" the required atomic types by adding an optional dependency on the **`portable-atomic`** crate.

I'm using a similar approach to the [bytes](https://github.com/tokio-rs/bytes) crate.